### PR TITLE
fix: use https for ScraperAPI URL

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -20,7 +20,7 @@ if not API_KEY:
     logging.error("SCRAPER_API_KEY environment variable is required")
     raise ValueError("SCRAPER_API_KEY environment variable must be set")
 
-SCRAPERAPI_URL = f'http://api.scraperapi.com?api_key={API_KEY}&url='
+SCRAPERAPI_URL = f'https://api.scraperapi.com?api_key={API_KEY}&url='
 
 USER_AGENTS = [
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',


### PR DESCRIPTION
## Summary
- use HTTPS scheme for ScraperAPI requests

## Testing
- `black --check scraper.py` *(fails: would reformat scraper.py)*
- `flake8 *.py` *(fails: many E501, W293, etc.)*
- `SCRAPER_API_KEY=demo python - <<'PY'
from scraper import get_page_content
print(get_page_content('http://example.com', retries=1))
PY` *(fails: HTTPSConnectionPool, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c39fa614188322ad999daf85f36f5a