### PR TITLE
fix: safeguard scraping state with lock

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -29,7 +29,8 @@ def test_generate_filename_sanitizes_domain(monkeypatch):
 def test_scrape_and_save_rejects_outside_path(monkeypatch, tmp_path):
     app = ScraperApp()
     app.update_progress = lambda *args, **kwargs: None
-    app.is_scraping = True
+    with app.state_lock:
+        app.is_scraping = True
     app.total_urls = 1
     app.completed_urls = 0
     app.failed_urls = []


### PR DESCRIPTION
## Summary
- introduce `state_lock` in `ScraperApp` to guard `is_scraping`
- synchronize start/stop and worker threads on scraping state
- update tests for lock-aware state toggling

## Testing
- `python -m pytest -q`
- `flake8 *.py tests/*.py` *(fails: many existing style violations across project)*
- `python manual_test.py` *(concurrent state toggle; no race conditions)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a9e57b0c83229c99ad2b830cacd5