### PR TITLE
feat: sanitize URLs in logs

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,14 +1,14 @@
+import logging
 import os
+
 from dotenv import load_dotenv
+from kivy.config import Config
+from ui import ScraperApp
 from utils import configure_logging  # Ensure this import is present
 
 # Load environment variables from .env file
 load_dotenv()
 configure_logging()
-
-from kivy.config import Config
-from ui import ScraperApp
-import logging
 
 # Configure Kivy settings from environment variables
 Config.set('graphics', 'multisamples', '0')  # Disable multisampling

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+import os
+import logging
+
+os.environ.setdefault("SCRAPER_API_KEY", "test")
+
+from utils import sanitize_url  # noqa: E402
+import scraper  # noqa: E402
+
+
+def test_sanitize_url_strips_control_chars():
+    raw = "http://example.com/\nattack\r"
+    assert sanitize_url(raw) == "http://example.com/attack"
+
+
+def test_validate_url_logs_sanitized(caplog):
+    bad = "http://example.com/\nattack"
+    with caplog.at_level(logging.DEBUG):
+        scraper.validate_url(bad)
+    for record in caplog.records:
+        assert "\n" not in record.getMessage()
+        assert "\r" not in record.getMessage()

--- a/ui.py
+++ b/ui.py
@@ -13,13 +13,13 @@ from kivy.uix.popup import Popup
 from kivy.uix.checkbox import CheckBox
 from kivy.uix.progressbar import ProgressBar
 from kivy.uix.scrollview import ScrollView
-from kivy.clock import Clock, mainthread
+from kivy.clock import mainthread
 from kivy.utils import platform as kivy_platform
 import threading
 import logging
 import time
-from scraper import scrape_text_data, save_data_to_file, scrape_multiple_urls, validate_url
-from utils import configure_logging, get_logger
+from scraper import scrape_text_data, save_data_to_file, validate_url
+from utils import configure_logging, get_logger, log_json
 
 
 def get_default_output_directory():
@@ -435,7 +435,13 @@ To modify settings:
             return filename
         except Exception as e:
             self.logger.error("Error generating filename")
-            self.logger.debug("Error generating filename for %s: %s", url, e)
+            log_json(
+                self.logger,
+                logging.DEBUG,
+                "Error generating filename",
+                url=url,
+                error=str(e),
+            )
             # Fallback filename
             timestamp = time.strftime("%Y%m%d_%H%M%S")
             return f"scraped_{timestamp}_{index:03d}.{file_format}"
@@ -496,7 +502,13 @@ To modify settings:
                 except Exception as e:
                     self.failed_urls.append(url)
                     self.logger.error("Error scraping URL")
-                    self.logger.debug("Error scraping %s: %s", url, e)
+                    log_json(
+                        self.logger,
+                        logging.DEBUG,
+                        "Error scraping",
+                        url=url,
+                        error=str(e),
+                    )
                     self.update_progress('✗ Error scraping URL', progress)
                 
                 # Small delay to prevent overwhelming servers

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,25 @@
+import json
 import logging
 import os
 import sys
 import platform
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+from typing import Any
+
+
+def sanitize_url(url: str) -> str:
+    """Remove newline and carriage-return characters from a URL."""
+    return url.replace("\n", "").replace("\r", "")
+
+
+def log_json(
+    logger: logging.Logger, level: int, message: str, **kwargs: Any
+) -> None:
+    """Log a structured JSON message with optional sanitization."""
+    if "url" in kwargs and isinstance(kwargs["url"], str):
+        kwargs["url"] = sanitize_url(kwargs["url"])
+    logger.log(level, json.dumps({"message": message, **kwargs}))
 
 
 def get_default_log_directory():


### PR DESCRIPTION
## Summary
- add `sanitize_url` and `log_json` helpers for safer, structured logging
- scrub user-provided URLs before logging and log JSON events
- cover URL sanitization with new tests and tidy imports for lint

## Testing
- `ruff check .`
- `pyright` *(fails: "Cannot access attribute 'bind' for class 'Label'")*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4ac2657988322a66a6e2a338d097a