### PR TITLE
feat: enforce log file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,14 @@ export SCRAPER_LOG_LEVEL=DEBUG
 python main.py
 ```
 
+### Log File Permissions
+
+On Unix-like systems the application restricts log files to owner read/write
+permissions (`0600`) to help protect sensitive data. Windows does not enforce
+Unix-style permissions; the application attempts to set permissions and logs a
+debug message if it cannot. Set `SCRAPER_ENV=development` to enable a
+verification step that warns when the expected permissions are not applied.
+
 ---
 
 *Generated on 2025-01-16T02:47:23Z*

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,11 @@
 import os
 import logging
+import stat
 
 os.environ.setdefault("SCRAPER_API_KEY", "test")
+os.environ.setdefault("SCRAPER_LOG_DIR", "/tmp/scraper_logs")
 
-from utils import sanitize_url  # noqa: E402
+from utils import sanitize_url, configure_logging  # noqa: E402
 import scraper  # noqa: E402
 
 
@@ -19,3 +21,11 @@ def test_validate_url_logs_sanitized(caplog):
     for record in caplog.records:
         assert "\n" not in record.getMessage()
         assert "\r" not in record.getMessage()
+
+
+def test_configure_logging_sets_strict_permissions(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCRAPER_ENV", "development")
+    log_path = configure_logging(log_dir=str(tmp_path))
+    assert log_path is not None
+    mode = stat.S_IMODE(os.stat(log_path).st_mode)
+    assert mode == 0o600


### PR DESCRIPTION
## Summary
- ensure logs are created with strict permissions and verify in development
- document cross-platform log permission behavior
- test that log file permissions are secure

## Testing
- `ruff check .`
- `pyright` *(fails: Import "dotenv" could not be resolved, attribute access issues, etc.)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4b422a06883228095e2fc45b8db93