### PR TITLE
feat: make fetch_url headers configurable

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -87,16 +87,37 @@ def validate_url(url):
         return False
 
 
-def fetch_url(url, timeout=10):
-    """Fetch content from the URL with a specified timeout and return the response text."""
+def fetch_url(url, timeout=10, headers=None):
+    """Fetch content from the URL and return the response text.
+
+    Args:
+        url: Target URL to fetch.
+        timeout: Request timeout in seconds.
+        headers: Optional dictionary of additional HTTP headers. User-provided values
+            override defaults.
+    """
     if not validate_url(url):  # ADDED: URL validation
         raise ValueError(f"Invalid URL: {url}")
-    
-    headers = {'User-Agent': get_random_user_agent()}
-    log_json(logger, logging.DEBUG, "Fetching URL", url=url, headers=headers)
-    
+
+    base_headers = {
+        "User-Agent": get_random_user_agent(),
+        "Accept": (
+            "text/html,application/xhtml+xml,application/xml;q=0.9,"
+            "image/avif,image/webp,*/*;q=0.8"
+        ),
+        "Accept-Language": "en-US,en;q=0.9",
+        "Connection": "close",
+        "DNT": "1",
+        "Upgrade-Insecure-Requests": "1",
+    }
+    if headers:
+        base_headers.update(headers)
+    log_json(logger, logging.DEBUG, "Fetching URL", url=url, headers=base_headers)
+
     try:
-        response = session.get(SCRAPERAPI_URL + url, headers=headers, timeout=timeout)
+        response = session.get(
+            SCRAPERAPI_URL + url, headers=base_headers, timeout=timeout
+        )
         response.raise_for_status()
         log_json(logger,
             logging.DEBUG,

--- a/tests/test_fetch_url.py
+++ b/tests/test_fetch_url.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import types
+
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+)
+os.environ.setdefault("SCRAPER_API_KEY", "test")
+
+import scraper  # noqa: E402
+
+
+class DummyResponse:
+    def __init__(self):
+        self.text = "ok"
+        self.content = b"ok"
+
+    def raise_for_status(self):
+        pass
+
+
+def test_fetch_url_uses_default_headers(monkeypatch):
+    captured = {}
+
+    def mock_get(url, headers=None, timeout=None):
+        captured.update(headers)
+        return DummyResponse()
+
+    monkeypatch.setattr(
+        scraper,
+        "session",
+        types.SimpleNamespace(get=mock_get),
+    )
+
+    result = scraper.fetch_url("http://example.com")
+    assert result == "ok"
+    assert captured["DNT"] == "1"
+    assert captured["Connection"] == "close"
+    assert "User-Agent" in captured
+
+
+def test_fetch_url_allows_custom_headers(monkeypatch):
+    captured = {}
+
+    def mock_get(url, headers=None, timeout=None):
+        captured.update(headers)
+        return DummyResponse()
+
+    monkeypatch.setattr(
+        scraper,
+        "session",
+        types.SimpleNamespace(get=mock_get),
+    )
+
+    custom = {"X-Test": "1", "User-Agent": "custom"}
+    scraper.fetch_url("http://example.com", headers=custom)
+    assert captured["X-Test"] == "1"
+    assert captured["User-Agent"] == "custom"


### PR DESCRIPTION
## Summary
- extend `fetch_url` with additional default headers like DNT and Connection: close
- allow callers to supply extra headers that override defaults
- add tests covering default and custom header behavior

## Testing
- `flake8 --select=F scraper.py tests/test_fetch_url.py`
- `flake8 tests/test_fetch_url.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4b5e3036c8322a18757c57003c27e