### PR TITLE
feat: make network retry settings configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ This sequence shows the core scraping workflow from user input to file output.
    echo "KIVY_FULLSCREEN=auto" >> .env
    echo "KIVY_WIDTH=800" >> .env
    echo "KIVY_HEIGHT=600" >> .env
+   # Optional network tuning
+   echo "SCRAPER_RETRY_TOTAL=5" >> .env
+   echo "SCRAPER_BACKOFF_FACTOR=1" >> .env
+   echo "SCRAPER_TIMEOUT=10" >> .env
+   echo "SCRAPER_PAGE_RETRIES=3" >> .env
+   echo "SCRAPER_RETRY_DELAY=5" >> .env
    ```
 
 ### Verification
@@ -137,6 +143,11 @@ python main.py
 | `KIVY_HEIGHT` | Window height | `600` |
 | `SCRAPER_LOG_LEVEL` | Logging level | `INFO` |
 | `SCRAPER_LOG_DIR` | Log directory | Platform-specific |
+| `SCRAPER_RETRY_TOTAL` | Max retry attempts for requests | `5` |
+| `SCRAPER_BACKOFF_FACTOR` | Exponential backoff factor | `1` |
+| `SCRAPER_TIMEOUT` | Request timeout in seconds | `10` |
+| `SCRAPER_PAGE_RETRIES` | Retries for page fetch helper | `3` |
+| `SCRAPER_RETRY_DELAY` | Initial delay before retries (s) | `5` |
 
 [[EVID: main.py:10-13 | Kivy configuration]] [[EVID: utils.py:76-87 | logging configuration]]
 

--- a/tests/test_fetch_url.py
+++ b/tests/test_fetch_url.py
@@ -57,3 +57,27 @@ def test_fetch_url_allows_custom_headers(monkeypatch):
     scraper.fetch_url("http://example.com", headers=custom)
     assert captured["X-Test"] == "1"
     assert captured["User-Agent"] == "custom"
+
+
+def test_fetch_url_uses_env_timeout(monkeypatch):
+    monkeypatch.setenv("SCRAPER_TIMEOUT", "1")
+    import importlib
+
+    importlib.reload(scraper)
+    captured = {}
+
+    def mock_get(url, headers=None, timeout=None):
+        captured["timeout"] = timeout
+        return DummyResponse()
+
+    monkeypatch.setattr(
+        scraper,
+        "session",
+        types.SimpleNamespace(get=mock_get),
+    )
+
+    scraper.fetch_url("http://example.com")
+    assert captured["timeout"] == 1
+
+    monkeypatch.delenv("SCRAPER_TIMEOUT", raising=False)
+    importlib.reload(scraper)


### PR DESCRIPTION
## Summary
- allow retry counts, backoff factor, and request timeouts to be set via environment variables
- document environment-based network tuning options
- test timeout override via `SCRAPER_TIMEOUT`

## Testing
- `flake8 *.py tests/*.py` *(fails: line-length and style issues across repository)*
- `pytest -q`

Please ensure branch protection requires these checks before merging.

------
https://chatgpt.com/codex/tasks/task_e_68c4b6f99ecc832284ea4c83985c62b9