### PR TITLE
Add security-focused tests for URL handling and scraping

### DIFF
--- a/tests/test_scrape_multiple_urls.py
+++ b/tests/test_scrape_multiple_urls.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("SCRAPER_API_KEY", "test")
+
+import scraper  # noqa: E402
+
+
+def test_scrape_multiple_urls_skips_invalid(monkeypatch):
+    called = []
+
+    def fake_scrape_text_data(url):
+        called.append(url)
+        return f"data for {url}"
+
+    monkeypatch.setattr(scraper, "scrape_text_data", fake_scrape_text_data)
+    urls = ["http://example.com", "http://localhost"]
+    results = scraper.scrape_multiple_urls(urls, max_workers=1)
+    assert called == ["http://example.com"]
+    assert len(results) == 1

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -25,6 +25,16 @@ def test_generate_filename_sanitizes_domain(monkeypatch):
         assert "." not in filename.split("_20240101")[0]
 
 
+def test_generate_filename_blocks_path_chars(monkeypatch):
+    app = ScraperApp()
+    monkeypatch.setattr(ui.time, "strftime", lambda fmt: "20240101_120000")
+    url = "https://evil.com/../bad"
+    filename = app._generate_filename(url, 1, "txt")
+    assert ".." not in filename
+    assert "/" not in filename
+    assert "\\" not in filename
+
+
 def test_scrape_and_save_rejects_outside_path(monkeypatch, tmp_path):
     app = ScraperApp()
     app.update_progress = lambda *args, **kwargs: None

--- a/tests/test_validate_url_security.py
+++ b/tests/test_validate_url_security.py
@@ -19,3 +19,9 @@ def test_unusual_port_rejected():
 
 def test_valid_url_allowed():
     assert scraper.validate_url("http://example.com")
+
+
+def test_non_http_scheme_rejected():
+    assert not scraper.validate_url("ftp://example.com")
+    assert not scraper.validate_url("javascript:alert(1)")
+    assert not scraper.validate_url("file:///etc/passwd")


### PR DESCRIPTION
## Summary
- test: extend URL validation coverage to reject non-http schemes
- test: ensure generated filenames strip path characters
- test: verify scrape_multiple_urls skips invalid URLs

## Testing
- `ruff check .`
- `pyright` *(fails: Import "dotenv" could not be resolved, plus 25 other errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4b7ef16248322b846f3457d027ed2