### PR TITLE
fix: annotate on_stop to return None

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -547,7 +547,7 @@ To modify settings:
             self.update_ui_state(False)
             self.logger.info("Background scraping thread completed")
 
-    def on_stop(self):
+    def on_stop(self) -> None:
         """Called when the app is about to close."""
         self.logger.info("App stopping")
         with self.state_lock:
@@ -562,7 +562,6 @@ To modify settings:
                 self.scraping_thread.join(timeout=30)
                 if self.scraping_thread.is_alive():
                     self.logger.warning("Scraping thread failed to terminate after 30s")
-        return True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- annotate `on_stop` with explicit `None` return type
- rely on implicit return and drop unused `True` value

## Testing
- `flake8 ui.py --max-line-length=130`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4c059aa648322b6dc826bd265fc22