### PR TITLE
test: guard header update in mock_get helpers

### DIFF
--- a/tests/test_fetch_url.py
+++ b/tests/test_fetch_url.py
@@ -24,7 +24,8 @@ def test_fetch_url_uses_default_headers(monkeypatch):
     captured = {}
 
     def mock_get(url, headers=None, timeout=None):
-        captured.update(headers)
+        if headers is not None:
+            captured.update(headers)
         return DummyResponse()
 
     monkeypatch.setattr(
@@ -44,7 +45,8 @@ def test_fetch_url_allows_custom_headers(monkeypatch):
     captured = {}
 
     def mock_get(url, headers=None, timeout=None):
-        captured.update(headers)
+        if headers is not None:
+            captured.update(headers)
         return DummyResponse()
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- prevent tests from calling `dict.update(None)` when no headers are provided by adding `headers is not None` checks in mock helpers

## Testing
- `flake8 tests/test_fetch_url.py`
- `pytest tests/test_fetch_url.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4c282f9948322be4af9d41b7c28c9